### PR TITLE
Add the prison performance team

### DIFF
--- a/datasets/prison_performance.yaml
+++ b/datasets/prison_performance.yaml
@@ -1,0 +1,8 @@
+name: prison_performance
+users:
+  - alpha_user_ERowland1
+  - alpha_user_graemechunter
+  - alpha_user_andriasarri
+  - alpha_user_CMedhurst
+  - alpha_user_Hannah-Waterfield
+  - alpha_user_wmartin-gss


### PR DESCRIPTION
Adding this file should add access for a team of users. They should now be able to send files from the Analytical Platform straight to the Performance Hub by uploading them to `s3://mojap-hub-exports/prison_performance`

Once deployed via `pulumi up` this should create a new rolepolicy for the 6 named users. They should have put access to the prison_performance folder/prefix and list access to the whole bucket. 

There will also be a corresponding change to the notification lambda.

## Future pull requests

Eventually we'll get users to make their own pull requests, a la `data-engineering-database-access`. But doing this myself for now as it's the only the second team and I want to confirm for myself how it all works. 