### PR TITLE
Update p1_nomis.yaml

### DIFF
--- a/push_datasets/p1_nomis.yaml
+++ b/push_datasets/p1_nomis.yaml
@@ -1,5 +1,5 @@
 name: p1_nomis
-target_bucket: arn:aws:s3:::dne-362298108429-prearrivals
+target_bucket: dne-362298108429-prearrivals
 users:
   - alpha_user_vonbraunbates
   - alpha_user_calumabarnett


### PR DESCRIPTION
Replaced ARN with just the bucket name to avoid the ARN needing to match regex rules:
```
[ERROR] ParamValidationError: Parameter validation failed:
Invalid bucket name "arn:aws:s3:::dne-362298108429-prearrivals": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$
```