### PR TITLE
Enable intervention copy to Modernisation Platform

### DIFF
--- a/push_datasets/interventions_to_modplatform.yaml
+++ b/push_datasets/interventions_to_modplatform.yaml
@@ -1,0 +1,4 @@
+name: probation_referrals_dump
+target_bucket: probation-referrals-datawarehouse # this is in Modernisation Platform
+users:
+  - alpha_user_sldblog


### PR DESCRIPTION
Configure push export for intervention data to the Modernisation Platform.

### How to set up the policy on the target bucket?

https://github.com/moj-analytical-services/data-engineering-exports/pull/26#discussion_r1058958627


### Data flow

- The data arrives in the `s3://mojap-hub-exports/probation_referral_dump` bucket via https://github.com/moj-analytical-services/create-a-derived-table/pull/109
- The `s3://probation-referrals-datawarehouse bucket` is the source for interventions business intelligence dashboards

Related to https://dsdmoj.atlassian.net/browse/IPB-46