### PR TITLE
Fix project name

### DIFF
--- a/pull_datasets/manage_offences.yaml
+++ b/pull_datasets/manage_offences.yaml
@@ -1,4 +1,4 @@
-name: manage_offences
+name: manage-offences
 pull_arns:
   - arn:aws:iam::754256621582:role/cloud-platform-7314e881eab2f63a-live
 users:


### PR DESCRIPTION
The project name is used in the name of a bucket. Bucket names can't contain underscores. This replaces an underscore with a dash.