### PR TITLE
CJSS-624/AP_to_CP_prod

### DIFF
--- a/pull_datasets/cjs_dashboard.yaml
+++ b/pull_datasets/cjs_dashboard.yaml
@@ -2,6 +2,7 @@ name: cjs-dashboard
 pull_arns:
   - arn:aws:iam::754256621582:role/cloud-platform-irsa-40eb2bac49e9da21-live
   - arn:aws:iam::754256621582:role/cloud-platform-irsa-3b969a65f8b52d3c-live
+  - arn:aws:iam::754256621582:role/cloud-platform-irsa-52943abf01a37496-live
 users:
   - alpha_user_lauraknowles
   - alpha_user_grahamison


### PR DESCRIPTION
Added new service account ARN to cjs-dashboard.yaml for cjs-dashboard-production app. This is to enable the app to read fro the mojap-cjs-dashhboard pull-bucket.