### PR TITLE
Initial implementation of new pull_push buckets

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -40,6 +40,10 @@ for file in pull_config_files:
     name = dataset["name"]
     pull_arns = dataset["pull_arns"]
     users = dataset["users"]
+    if "is_writable" in dataset.keys():
+        writable = dataset["allow_push"]
+    else:
+        writable = False
 
     pull_bucket = Bucket(
         name=f"mojap-{name}",
@@ -47,7 +51,7 @@ for file in pull_config_files:
     )
 
     # Add bucket policy allowing the specified arn to read
-    bucket_policy = Output.all(bucket_arn=pull_bucket.arn, pull_arns=pull_arns).apply(
+    bucket_policy = Output.all(bucket_arn=pull_bucket.arn, pull_arns=pull_arns, allow_push=writable).apply(
         pull.create_pull_bucket_policy
     )
     BucketPolicy(

--- a/data_engineering_exports/pull.py
+++ b/data_engineering_exports/pull.py
@@ -28,33 +28,69 @@ def create_pull_bucket_policy(args: Dict[str, str]) -> AwaitableGetPolicyDocumen
     """
     bucket_arn = args.pop("bucket_arn")
     pull_arns = args.pop("pull_arns")
-
-    bucket_policy = get_policy_document(
-        statements=[
-            GetPolicyDocumentStatementArgs(
-                actions=[
-                    "s3:GetObject",
-                    "s3:GetObjectAcl",
-                    "s3:GetObjectVersion",
-                ],
-                principals=[
-                    GetPolicyDocumentStatementPrincipalArgs(
-                        identifiers=pull_arns, type="AWS"
-                    )
-                ],
-                resources=[bucket_arn + "/*"],
-            ),
-            GetPolicyDocumentStatementArgs(
-                actions=["s3:ListBucket"],
-                principals=[
-                    GetPolicyDocumentStatementPrincipalArgs(
-                        identifiers=pull_arns, type="AWS"
-                    )
-                ],
-                resources=[bucket_arn],
-            ),
-        ]
-    )
+    allow_push = args.pop("allow_push", False)
+    writable_actions = [
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersion",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:PutObjectTagging",
+        "s3:RestoreObject",
+    ]
+    standard_actions = [
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersion",
+    ]
+    if allow_push:
+        bucket_policy = get_policy_document(
+            statements=[
+                GetPolicyDocumentStatementArgs(
+                    actions=writable_actions,
+                    principals=[
+                        GetPolicyDocumentStatementPrincipalArgs(
+                            identifiers=pull_arns, type="AWS"
+                        )
+                    ],
+                    resources=[bucket_arn + "/*"],
+                ),
+                GetPolicyDocumentStatementArgs(
+                    actions=["s3:ListBucket"],
+                    principals=[
+                        GetPolicyDocumentStatementPrincipalArgs(
+                            identifiers=pull_arns, type="AWS"
+                        )
+                    ],
+                    resources=[bucket_arn],
+                ),
+            ]
+        )
+    else:
+        bucket_policy = get_policy_document(
+            statements=[
+                GetPolicyDocumentStatementArgs(
+                    actions=standard_actions,
+                    principals=[
+                        GetPolicyDocumentStatementPrincipalArgs(
+                            identifiers=pull_arns, type="AWS"
+                        )
+                    ],
+                    resources=[bucket_arn + "/*"],
+                ),
+                GetPolicyDocumentStatementArgs(
+                    actions=["s3:ListBucket"],
+                    principals=[
+                        GetPolicyDocumentStatementPrincipalArgs(
+                            identifiers=pull_arns, type="AWS"
+                        )
+                    ],
+                    resources=[bucket_arn],
+                ),
+            ]
+        )
     return bucket_policy
 
 

--- a/pull_datasets/pull_permission_test.yaml
+++ b/pull_datasets/pull_permission_test.yaml
@@ -3,3 +3,5 @@ pull_arns:
   - arn:aws:iam::684969100054:role/restricted-admin
 users:
   - alpha_user_jhpyke
+allow_push:
+  - True


### PR DESCRIPTION
This PR adds a new flag to allow out of account roles write access on request. This functionality is disabled by default.