### PR TITLE
Fix legacy variable name

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -40,7 +40,7 @@ for file in pull_config_files:
     name = dataset["name"]
     pull_arns = dataset["pull_arns"]
     users = dataset["users"]
-    if "is_writable" in dataset.keys():
+    if "allow_push" in dataset.keys():
         writable = dataset["allow_push"]
     else:
         writable = False


### PR DESCRIPTION
This PR actually enables the functionality in the previous PR, which was non-functional due to a reference to a variable name from an older version of the code during development.