### PR TITLE
Removing account that doesn't exist

### DIFF
--- a/pull_datasets/yjb_lambda_bucket.yaml
+++ b/pull_datasets/yjb_lambda_bucket.yaml
@@ -5,7 +5,6 @@ users:
   - alpha_user_alexkey-yjb
   - alpha_user_orianapdm
   - alpha_user_rowanyjb
-  - alpha_user_strevs81
   - alpha_user_Rhian-Manley
 allow_push:
   - True


### PR DESCRIPTION
An account requested by YJB initially still doesn't correspond to an active user. This PR removes said user so they don't cause deployment failures until this can change.