### PR TITLE
Test adding dummy pull_arn to wmp-proj.yaml

### DIFF
--- a/pull_datasets/wmp-proj.yaml
+++ b/pull_datasets/wmp-proj.yaml
@@ -1,7 +1,6 @@
   name: wmp-proj
-  # pull_arns:
-  #   - role1
-  #   - role2
+  pull_arns:
+    - arn:aws:iam::754256621582:role/cloud-platform-irsa-40ebk3dc49e9m34l-live
   users:
     - alpha_user_ani-setchi
     - alpha_user_maryboeker


### PR DESCRIPTION
The file is currently causing a failure in pulumi preview, due to missing pull_arn value. Added a dummy value so that S3 bucket can be created (initally for internal use only).