### PR TITLE
Remove artifacts bucket

### DIFF
--- a/pull_datasets/mlflow_sandbox_artifacts.yaml
+++ b/pull_datasets/mlflow_sandbox_artifacts.yaml
@@ -1,7 +1,0 @@
-name: mlflow-sandbox-artifacts
-pull_arns:
-  - arn:aws:iam::684969100054:role/MLFlowServerRole
-users:
-  - alpha_user_priyabasker23
-allow_push:
-  - True


### PR DESCRIPTION
The bucket was created to test Mlflow functionality. Its is not needed anymore. So it can be removed. 