### PR TITLE
Removing unused config

### DIFF
--- a/pull_datasets/bold_rr_ops.yaml
+++ b/pull_datasets/bold_rr_ops.yaml
@@ -1,8 +1,0 @@
-name: bold-rr-ops
-pull_arns:
-  - arn:aws:iam::754256621582:role/cloud-platform-0bd2f454db950c2e-live
-users:
-  - alpha_user_mshodge
-  - alpha_user_andreassoteriadesmoj
-  - alpha_user_wmartin-gss
-  


### PR DESCRIPTION
After consulting with the owners on slack, this PR removes a config that is no longer in use so it can be cleaned up