### PR TITLE
rm mshodge

### DIFF
--- a/pull_datasets/probation-search-model-export.yaml
+++ b/pull_datasets/probation-search-model-export.yaml
@@ -1,7 +1,0 @@
-name: probation-search-model-export
-pull_arns:
-  - arn:aws:iam::381491960855:role/hmpps-probation-search-dev-sagemaker-exec-role
-  - arn:aws:iam::992382429243:role/hmpps-probation-search-preprod-sagemaker-exec-role
-  - arn:aws:iam::992382429243:role/hmpps-probation-search-prod-sagemaker-exec-role
-users:
-  - alpha_user_mshodge


### PR DESCRIPTION
This was never used in the project (the AP team used database access as a process instead) so safe to remove, I think.

👋 