### PR TITLE
Remove and update pipelines where roles no-longer exist

### DIFF
--- a/pull_datasets/lcjb-explorer.yaml
+++ b/pull_datasets/lcjb-explorer.yaml
@@ -1,6 +1,6 @@
 name: lcjb-explorer
 pull_arns:
-  - arn:aws:iam::754256621582:role/cloud-platform-irsa-9506f291e38addd0-live
+  - arn:aws:iam::593291632749:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_48361bdb022cb721
 users:
   - alpha_user_hannah-faculty
   - alpha_user_adp-faculty

--- a/push_datasets/interventions_to_modplatform.yaml
+++ b/push_datasets/interventions_to_modplatform.yaml
@@ -1,4 +1,0 @@
-name: probation_referrals_dump
-target_bucket: probation-referrals-datawarehouse # this is in Modernisation Platform
-users:
-  - alpha_user_sldblog


### PR DESCRIPTION
This PR removes 1 role where the cloud platform role no longer exists, as well as an exports config where the only user no longer exists.