### PR TITLE
Update yjb_lambda_bucket.yaml

### DIFF
--- a/pull_datasets/yjb_lambda_bucket.yaml
+++ b/pull_datasets/yjb_lambda_bucket.yaml
@@ -3,7 +3,6 @@ pull_arns:
   - arn:aws:iam::586794462316:role/s3-cross-account-replication-lambda-role
 users:
   - alpha_user_alexkey-yjb
-  - alpha_user_orianapdm
   - alpha_user_Rhian-Manley
 allow_push:
   - True

--- a/pull_datasets/yjb_lambda_bucket.yaml
+++ b/pull_datasets/yjb_lambda_bucket.yaml
@@ -1,6 +1,6 @@
 name: youth-justice-board
 pull_arns:
-  - arn:aws:iam::066012302209:role/service-role/S3-cross-account-replication-role-7niuq7ek
+  - arn:aws:iam::586794462316:role/s3-cross-account-replication-lambda-role
 users:
   - alpha_user_alexkey-yjb
   - alpha_user_orianapdm


### PR DESCRIPTION
Old ARN is depricated, and needs to be replaced to fix the broken cross-account data sharing lambda function.

https://mojdt.slack.com/archives/C4PF7QAJZ/p1772446970208829